### PR TITLE
Use correct pwm-period in default fan-control.json

### DIFF
--- a/etc/fan-control.json
+++ b/etc/fan-control.json
@@ -1,7 +1,7 @@
 {
-    "pwmchip": -1,
+    "pwmchip": 1,
     "gpio": 0,
-    "pwm-period": 10000,
+    "pwm-period": 4000000,
     "temp-map": [
         {
             "temp": 40,


### PR DESCRIPTION
Hey there, thank you for this repository, this helped me get my Radxa PoE Hat fan running in Armbian.

One thing I had to fix though was the `pwm-period` in the default `fan-control.json`. After I set this to `4000000` my fan started working as expected. Before it would only ever start when I set the duty to `10000`.